### PR TITLE
Fix FILENAME_MAX (should be 256)

### DIFF
--- a/zint/zint.py
+++ b/zint/zint.py
@@ -153,7 +153,7 @@ ZINT_ROWS_MAX = 178
 ZINT_COLS_MAX = 178
 ZINT_ERR_SIZE = 100
 
-FILENAME_MAX = pathconf('.', 'PC_PATH_MAX')
+FILENAME_MAX = 256
 
 def instr (text):
 	l = len(text) + 1


### PR DESCRIPTION
`struct zint_symbol` has `char outfile[256];` definition, but `pathconf('.', 'PC_PATH_MAX')` can be 4096