### PR TITLE
Upgrade to support zint 2.6.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Python-Zint is a ctypes interface to libzint of 
+Python-Zint is a ctypes interface to libzint of
 Robin Stuart's Zint project:
 
 <http://www.zint.org.uk/>
@@ -15,7 +15,7 @@ Generate a QRCode saved to file out.png::
 
     import zint
     import sys
-    
+
     symbol = zint.ZBarcode_Create()
     symbol.contents.symbology = zint.BARCODE_QRCODE
     symbol.contents.scale = 2.5
@@ -38,7 +38,7 @@ Generate a QRCode in memory only::
 
     import zint
     import sys
-    
+
     symbol = zint.ZBarcode_Create()
     symbol.contents.symbology = zint.BARCODE_QRCODE
     symbol.contents.scale = 0
@@ -104,3 +104,12 @@ Result
     * *** *  * * *  * *      *** * *    *
     *     *    ** *  **** * * * * * **  *
     *******  * ****  *  ** **   *  ***  *
+
+
+Versions
+==========
+
+If you are using a zintlib version 2.6.2 or less, you need python-zint version 1.1
+
+For zintlib version 2.6.3+ then use python-zint version 1.2
+

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import codecs
 import os
+import zint
 from setuptools import setup
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -25,7 +26,7 @@ Usage closely follows the C API:
     pass
 
 setup(name='zint',
-      version='1.1',
+      version=zint.__version__,
       description='Python ctypes interface to libzint',
       long_description=description.__doc__.strip(),
       url='http://github.com/jmptbl/python-zint',

--- a/zint/zint.py
+++ b/zint/zint.py
@@ -84,6 +84,7 @@ BARCODE_ISBNX = 69
 BARCODE_RM4SCC = 70
 BARCODE_DATAMATRIX = 71
 BARCODE_EAN14 = 72
+BARCODE_VIN = 73
 BARCODE_CODABLOCKF = 74
 BARCODE_NVE18 = 75
 BARCODE_JAPANPOST = 76
@@ -111,6 +112,7 @@ BARCODE_HIBC_BLOCKF = 110
 BARCODE_HIBC_AZTEC = 112
 BARCODE_DOTCODE = 115
 BARCODE_HANXIN = 116
+BARCODE_MAILMARK = 121
 BARCODE_AZRUNE = 128
 BARCODE_CODE32 = 129
 BARCODE_EANX_CC = 130
@@ -260,6 +262,7 @@ zint_symbol._fields_ = [
 	('input_mode', c_int),
 	('eci', c_int),
 	('text', (c_ubyte * ZINT_TEXT_SIZE)),
+	('fontsize', c_int),
 	('rows', c_int),
 	('width', c_int),
 	('primary', (c_char * ZINT_PRIMARY_SIZE)),
@@ -325,21 +328,21 @@ try:
 	ZBarcode_Version.argtypes = []
 except:
 	def ZBarcode_Version ():
-		if ZBarcode_ValidID(BARCODE_DOTCODE) == 1:
-			return 20600
+		if ZBarcode_ValidID(BARCODE_VIN) == 1:
+			return 20603
 		return 0
 
-if ZBarcode_Version() < 20600:
-	raise RuntimeError('libzint >=2.6.0 required')
+if ZBarcode_Version() < 20603:
+	raise RuntimeError('libzint >=2.6.3 required')
 
-__version__ = '1.1'
+__version__ = '1.2'
 
 __all__ = [
 	'__version__', 'instr', 'infile', 'bitmapbuf',
 	'ZBarcode_Create', 'ZBarcode_Delete',
 	'ZBarcode_Encode', 'ZBarcode_Encode_File', 'ZBarcode_Print',
 	'ZBarcode_Encode_and_Print','ZBarcode_Encode_File_and_Print',
-	'ZBarcode_Buffer', 'ZBarcode_Encode_and_Buffer', 
+	'ZBarcode_Buffer', 'ZBarcode_Encode_and_Buffer',
 	'ZBarcode_Encode_File_and_Buffer', 'ZBarcode_ValidID',
 	'ZBarcode_Version',
 	'zint_symbol', 'zint_render', 'zint_render_hexagon',
@@ -361,7 +364,7 @@ __all__ = [
 	'BARCODE_MAXICODE', 'BARCODE_QRCODE', 'BARCODE_CODE128B',
 	'BARCODE_AUSPOST', 'BARCODE_AUSREPLY', 'BARCODE_AUSROUTE',
 	'BARCODE_AUSREDIRECT', 'BARCODE_ISBNX', 'BARCODE_RM4SCC',
-	'BARCODE_DATAMATRIX', 'BARCODE_EAN14', 'BARCODE_CODABLOCKF',
+	'BARCODE_DATAMATRIX', 'BARCODE_EAN14', 'BARCODE_VIN', 'BARCODE_CODABLOCKF',
 	'BARCODE_NVE18', 'BARCODE_JAPANPOST', 'BARCODE_KOREAPOST',
 	'BARCODE_RSS14STACK', 'BARCODE_RSS14STACK_OMNI', 'BARCODE_RSS_EXPSTACK',
 	'BARCODE_PLANET', 'BARCODE_MICROPDF417', 'BARCODE_ONECODE',
@@ -370,7 +373,7 @@ __all__ = [
 	'BARCODE_MICROQR', 'BARCODE_HIBC_128', 'BARCODE_HIBC_39',
 	'BARCODE_HIBC_DM', 'BARCODE_HIBC_QR', 'BARCODE_HIBC_PDF',
 	'BARCODE_HIBC_MICPDF', 'BARCODE_HIBC_BLOCKF', 'BARCODE_HIBC_AZTEC',
-	'BARCODE_DOTCODE', 'BARCODE_HANXIN',
+	'BARCODE_DOTCODE', 'BARCODE_HANXIN', 'BARCODE_MAILMARK',
 	'BARCODE_AZRUNE', 'BARCODE_CODE32', 'BARCODE_EANX_CC',
 	'BARCODE_EAN128_CC', 'BARCODE_RSS14_CC', 'BARCODE_RSS_LTD_CC',
 	'BARCODE_RSS_EXP_CC', 'BARCODE_UPCA_CC', 'BARCODE_UPCE_CC',


### PR DESCRIPTION
zint introduced a new symbol property for `fontsize` shortly before the
release of 2.6.3.  This casues calls to `bitmapbuf` to fail.

This commit adds the `fontsize` property to the symbol object and
includes two additinal symbologies added in 2.6.3.

Resolves: #4 